### PR TITLE
FED-539: Add TLS support to gomemcache

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -20,6 +20,7 @@ package memcache
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -145,8 +146,9 @@ type Client struct {
 
 	selector ServerSelector
 
-	lk       sync.Mutex
-	freeconn map[string][]*conn
+	lk        sync.Mutex
+	freeconn  map[string][]*conn
+	TlsConfig *tls.Config
 }
 
 // Item is an item to be got or stored in a memcached server.
@@ -254,15 +256,27 @@ func (cte *ConnectTimeoutError) Error() string {
 }
 
 func (c *Client) dial(addr net.Addr) (net.Conn, error) {
-	nc, err := net.DialTimeout(addr.Network(), addr.String(), c.netTimeout())
+	type connError struct {
+		cn  net.Conn
+		err error
+	}
+
+	var (
+		nc  net.Conn
+		err error
+	)
+	nd := net.Dialer{Timeout: c.netTimeout()}
+	if c.TlsConfig != nil {
+		nc, err = tls.DialWithDialer(&nd, addr.Network(), addr.String(), c.TlsConfig)
+	} else {
+		nc, err = nd.Dial(addr.Network(), addr.String())
+	}
 	if err == nil {
 		return nc, nil
 	}
-
 	if ne, ok := err.(net.Error); ok && ne.Timeout() {
 		return nil, &ConnectTimeoutError{addr}
 	}
-
 	return nil, err
 }
 

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -19,6 +19,8 @@ package memcache
 
 import (
 	"bufio"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -31,9 +33,10 @@ import (
 )
 
 const testServer = "localhost:11211"
+const testServerTLS = "localhost:11212"
 
-func setup(t *testing.T) bool {
-	c, err := net.Dial("tcp", testServer)
+func setup(t *testing.T, server string) bool {
+	c, err := net.Dial("tcp", server)
 	if err != nil {
 		t.Skipf("skipping test; no server running at %s", testServer)
 	}
@@ -43,7 +46,7 @@ func setup(t *testing.T) bool {
 }
 
 func TestLocalhost(t *testing.T) {
-	if !setup(t) {
+	if !setup(t, testServer) {
 		return
 	}
 	testWithClient(t, New(testServer))
@@ -317,4 +320,29 @@ func BenchmarkOnItem(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		c.onItem(&item, dummyFn)
 	}
+}
+
+func TestLocalhostTLS(t *testing.T) {
+	if !setup(t, testServerTLS) {
+		return
+	}
+	c := New(testServerTLS)
+
+	caCert, err := ioutil.ReadFile("ca.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+	tlsConfig := &tls.Config{
+		RootCAs:    caCertPool,
+		ServerName: "localhost",
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.TlsConfig = tlsConfig
+	testWithClient(t, c)
 }


### PR DESCRIPTION
- Fed/Gov requires that we have encryption of all data in transit
- Encrypted connection to memcached requires that we connect via TLS
- `bradfitz/gomemcache` doesn't support TLS
- We are modifying the repo in this fork to support TLS connections